### PR TITLE
[TypeScript] Fix 'done' type in Async/IteratorState

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -51,7 +51,7 @@ export function asyncIteratorThrow<T>(x: Iterator<T> | AsyncIterator<T>, y?: any
 }
 
 class IteratorState<T> {
-  done: boolean = true;
+  done: boolean | undefined = true;
   constructor(private iterator: Iterator<T>) {}
   modify(fn: (x: Iterator<T>) => IteratorResult<T>) {
     try {
@@ -113,7 +113,7 @@ const asyncMapSequential: AsyncMapFn = async (xs, fn) => {
 const asyncMapParallel: AsyncMapFn = (xs, fn) => Promise.all(xs.map(fn));
 
 class AsyncIteratorState<T> {
-  done: boolean | Promise<boolean> = true;
+  done: boolean | Promise<boolean | undefined> | undefined = true;
   constructor(private iterator: Iterator<T> | AsyncIterator<T>) {}
   async modify(fn: (x: Iterator<T> | AsyncIterator<T>) => IteratorResult<T> | Promise<IteratorResult<T>>) {
     // Fetch the result through an async function so failure is always captured as a rejected


### PR DESCRIPTION
Hi. At the moment `IteratorResult` has the following signature:
```TypeScript
interface IteratorYieldResult<TYield> {
    done?: false;
    value: TYield;
}

interface IteratorReturnResult<TReturn> {
    done: true;
    value: TReturn;
}

type IteratorResult<T, TReturn = any> = IteratorYieldResult<T> | IteratorReturnResult<TReturn>;
```
https://github.com/microsoft/TypeScript/commit/e8bf9584aa74aabfecb51a02edb13e3657508274

As you can see, `done` is of type `boolean | undefined`, while in `IteratorState` and` AsyncIteratorState` it's of `boolean` type, what is causing the compilation error. I have changed the type of `done` to match the actual type.